### PR TITLE
type of YR_COMPILER_CALLBACK_FUNC changed

### DIFF
--- a/libqs.c
+++ b/libqs.c
@@ -1908,8 +1908,7 @@ void report_error(
                   int error_level,
                   const char* file_name,
                   int line_number,
-                  const char* message,
-                  void* user_data)
+                  const char* message)
 {
     if (error_level == YARA_ERROR_LEVEL_ERROR)
     {
@@ -2029,7 +2028,7 @@ void quicksand_yara_mem(const unsigned char* data, unsigned long data_len, char 
         printf("error 2\n");
     
   
-    yr_compiler_set_callback(compiler, report_error, NULL);
+    yr_compiler_set_callback(compiler, report_error);
     
     
     //int errors = yr_compiler_add_string(compiler, rule, "quicksand");


### PR DESCRIPTION
I tried to ./build.sh on a freshly installed debian system (with the following extra packages installed: git, build-essential, yara, libyara-dev, libzip-dev) and got the following errors and warnings from gcc:

	In file included from quicksand.c:22:0:
	libqs.c: In function ‘quicksand_yara_mem’:
	libqs.c:2032:40: warning: passing argument 2 of ‘yr_compiler_set_callback’ from incompatible pointer type
		 yr_compiler_set_callback(compiler, report_error, NULL);
											^
	In file included from /usr/include/yara.h:27:0,
					 from libqs.c:41,
					 from quicksand.c:22:
	/usr/include/yara/compiler.h:128:6: note: expected ‘YR_COMPILER_CALLBACK_FUNC’ but argument is of type ‘void (*)(int,  const char *, int,  const char *, void *)’
	 void yr_compiler_set_callback(
		  ^
	In file included from quicksand.c:22:0:
	libqs.c:2032:5: error: too many arguments to function ‘yr_compiler_set_callback’
		 yr_compiler_set_callback(compiler, report_error, NULL);
		 ^
	In file included from /usr/include/yara.h:27:0,
					 from libqs.c:41,
					 from quicksand.c:22:
	/usr/include/yara/compiler.h:128:6: note: declared here
	 void yr_compiler_set_callback(
		  ^

The following YARA versions are installed:

	$ aptitude show {libyara-dev,yara} | grep Version
	Version: 3.1.0-2
	Version: 3.1.0-2

I honestly don't know, in which direction, the YARA API was changed (wether user_data was added or removed) but wanted to provide this PR for reference and fellow people, that stumble upon the same problem.
