### PR TITLE
Update quicksand_exploits.yara

### DIFF
--- a/quicksand_exploits.yara
+++ b/quicksand_exploits.yara
@@ -641,6 +641,30 @@ rule warning_vb_macro {
             1 of them
 }
 
+
+rule warning_js_embed {
+	meta:
+		is_exploit = false
+		is_warning = true
+		is_feature = true
+		rank = 3
+		revision = "1"
+		date = "Apr 12 2017"
+		author = "@tylabs"
+		release = "lite"
+		copyright = "QuickSand.io (c) Copyright 2015. All rights reserved."
+		tlp = "white"
+		sigtype = "cryptam_exploit"
+		desc = "Embedded js"
+	strings:
+		$s1 = {6a 73 00}
+		$s2 = "Package"
+		$s3 = {2e 00 6a 00 73}
+		$s4 = "Ole10Native" wide
+	condition:
+            3 of them
+}
+
 rule exploit_activex_execute_shell {
 	meta:
 		is_exploit = true
@@ -775,26 +799,3 @@ rule warning_vb_fileio {
     condition:
         1 of them
     }
-
-rule warning_js_embed {
-	meta:
-		is_exploit = false
-		is_warning = true
-		is_feature = true
-		rank = 3
-		revision = "1"
-		date = "Apr 12 2017"
-		author = "@tylabs"
-		release = "lite"
-		copyright = "QuickSand.io (c) Copyright 2015. All rights reserved."
-		tlp = "white"
-		sigtype = "cryptam_exploit"
-		desc = "Embedded js"
-	strings:
-		$s1 = {6a 73 00}
-		$s2 = "Package"
-		$s3 = {2e 00 6a 00 73}
-		$s4 = "Ole10Native" wide
-	condition:
-            3 of them
-}


### PR DESCRIPTION
Fix for: 
_quicksand_exploits.yara(671): error: undefined identifier "warning_js_embed"_.
Adding the warning_js_embed rule before the exploit_activex_execute_shell rule solves the issue.